### PR TITLE
Support vz format of the kernel version information

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -19,7 +19,11 @@ class KernelVersion():
             if secondary_part[iter].isalpha():
                 self.build = secondary_part[:iter - 1]
                 suffix = secondary_part[iter:]
-                self.distro, self.arch = suffix.split(".")
+                # There is no information about arch when we have vzX suffix
+                if suffix.startswith("vz"):
+                    self.distro = suffix.split(".")[0]
+                else:
+                    self.distro, self.arch = suffix.split(".")
                 break
 
     def _extract_no_build(self, version: str):
@@ -42,10 +46,15 @@ class KernelVersion():
 
     def __str__(self):
         """Return a string representation of a KernelVersion object."""
-        if self.build == "":
-            return f"{self.major}.{self.minor}.{self.patch}.{self.distro}.{self.arch}"
+        result = f"{self.major}.{self.minor}.{self.patch}"
+        if self.build != "":
+            result += f"-{self.build}"
 
-        return f"{self.major}.{self.minor}.{self.patch}-{self.build}.{self.distro}.{self.arch}"
+        result += f".{self.distro}"
+        if self.arch != "":
+            result += f".{self.arch}"
+
+        return result
 
     def __lt__(self, other):
         if self.major < other.major or self.minor < other.minor or self.patch < other.patch:

--- a/tests/versiontests.py
+++ b/tests/versiontests.py
@@ -22,6 +22,9 @@ class KernelVersionTests(unittest.TestCase):
     def test_kernel_parse_no_build(self):
         self._check_parse("3.10.0.el7.x86_64", "3.10.0.el7.x86_64")
 
+    def test_kernel_parse_virtuozo(self):
+        self._check_parse("3.10.0-1160.90.1.vz7.200.7", "3.10.0-1160.90.1.vz7")
+
     def test_compare_simple_equal(self):
         kernel1 = version.KernelVersion("3.10.0-1160.95.1.el7.x86_64")
         kernel2 = version.KernelVersion("3.10.0-1160.95.1.el7.x86_64")


### PR DESCRIPTION
Unfortiantly it have no information about arch, so we have to skip it.